### PR TITLE
fix missed function rename in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Adds graceful shutdown and Kubernetes readiness / liveness checks for any HTTP a
 const http = require('http');
 const terminus = require('@godaddy/terminus');
 
-function onSigterm () {
+function onSignal () {
   console.log('server is starting cleanup');
   return Promise.all([
     // your clean logic, like closing database connections


### PR DESCRIPTION
Missed this rename in the readme while implementing #10 