### PR TITLE
Decorate with health check only if there's health checks defined

### DIFF
--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -73,10 +73,12 @@ function terminus(server, options = {}) {
 
   const logger = options.logger || noop;
 
-  decorateWithHealthCheck(server, {
-    healthChecks,
-    logger
-  });
+  if (Object.keys(healthChecks).length > 0) {
+    decorateWithHealthCheck(server, {
+      healthChecks,
+      logger
+    });
+  }
 
   decorateWithSignalHandler(server, {
     signal,


### PR DESCRIPTION
This avoids adding a request listener overhead for health checks if there's no health checks defined.