### PR TITLE
Update `timeout` option documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const options = {
   },
 
   // cleanup options
-  timeout: 1000,                   // [optional = 5000] number of milliseconds before forcefull exiting
+  timeout: 1000,                   // [optional = 1000] number of milliseconds before forcefull exiting
   signal,                          // [optional = 'SIGTERM'] what signal to listen for relative to shutdown
   onSignal,                        // [optional] cleanup function, returning a promise (used to be onSigterm)
   onShutdown,                      // [optional] called right before exiting


### PR DESCRIPTION
Looks like it defaults to 1000 in the code https://github.com/godaddy/terminus/blob/1ff2ae9b54abdf3acb1aa1619ed51d48ce787361/lib/terminus.js#L70 and not 5000 as documented.