### PR TITLE
fix(on-signal): fail healthchecks on signal rec

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ const options = {
   // cleanup options
   timeout: 1000,                   // [optional = 1000] number of milliseconds before forcefull exiting
   signal,                          // [optional = 'SIGTERM'] what signal to listen for relative to shutdown
+  beforeShutdown,                  // [optional] called before the HTTP server starts its shutdown
   onSignal,                        // [optional] cleanup function, returning a promise (used to be onSigterm)
   onShutdown,                      // [optional] called right before exiting
 

--- a/lib/standalone-tests/terminus.onsignal.fail.js
+++ b/lib/standalone-tests/terminus.onsignal.fail.js
@@ -1,0 +1,22 @@
+'use strict'
+const http = require('http')
+const server = http.createServer((req, res) => res.end('hello'))
+
+const terminus = require('../terminus')
+const SIGNAL = 'SIGINT'
+
+terminus(server, {
+  healthChecks: {
+    '/health': () => Promise.resolve()
+  },
+  signal: SIGNAL,
+  beforeShutdown: () => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 1000)
+    })
+  }
+})
+
+server.listen(8000, () => {
+  process.kill(process.pid, SIGNAL)
+})

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const stoppable = require('stoppable')
 const { promisify } = require('es6-promisify')
 
@@ -14,6 +15,20 @@ function noopResolves () {
   return Promise.resolve()
 }
 
+function sendSuccess (res) {
+  res.statusCode = 200
+  res.end(SUCCESS_RESPONSE)
+}
+
+function sendFailure (res) {
+  res.statusCode = 503
+  res.end(FAILURE_RESPONSE)
+}
+
+const state = {
+  isShuttingDown: false
+}
+
 function noop () {}
 
 function decorateWithHealthCheck (server, options) {
@@ -23,15 +38,16 @@ function decorateWithHealthCheck (server, options) {
     server.removeListener('request', listener)
     server.on('request', (req, res) => {
       if (healthChecks[req.url]) {
+        if (state.isShuttingDown) {
+          return sendFailure(res)
+        }
         healthChecks[req.url]()
           .then(() => {
-            res.statusCode = 200
-            res.end(SUCCESS_RESPONSE)
+            sendSuccess(res)
           })
           .catch((error) => {
             logger('healthcheck failed', error)
-            res.statusCode = 503
-            res.end(FAILURE_RESPONSE)
+            sendFailure(res)
           })
       } else {
         listener(req, res)
@@ -41,14 +57,17 @@ function decorateWithHealthCheck (server, options) {
 }
 
 function decorateWithSignalHandler (server, options) {
-  const { signal, onSignal, onShutdown, timeout, logger } = options
+  const { signal, onSignal, beforeShutdown, onShutdown, timeout, logger } = options
 
   stoppable(server, timeout)
 
   const asyncServerStop = promisify(server.stop).bind(server)
 
   function cleanup () {
-    asyncServerStop()
+    state.isShuttingDown = true
+
+    beforeShutdown()
+      .then(() => asyncServerStop())
       .then(() => onSignal())
       .then(() => onShutdown())
       .then(() => {
@@ -65,9 +84,10 @@ function decorateWithSignalHandler (server, options) {
 
 function terminus (server, options = {}) {
   const { signal='SIGTERM', 
-          timeout=1000, 
-          healthChecks={}, 
-          onShutdown=noopResolves, 
+          timeout=1000,
+          healthChecks={},
+          onShutdown=noopResolves,
+          beforeShutdown=noopResolves,
           logger=noop } = options
   const onSignal = options.onSignal || options.onSigterm || noopResolves
 
@@ -81,6 +101,7 @@ function terminus (server, options = {}) {
   decorateWithSignalHandler(server, {
     signal,
     onSignal,
+    beforeShutdown,
     onShutdown,
     timeout,
     logger

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 const http = require('http')
-const { execFileSync } = require('child_process')
+const { execFile, execFileSync } = require('child_process')
 
 const expect = require('chai').expect
 const fetch = require('node-fetch')
@@ -79,6 +79,20 @@ describe('Terminus', () => {
           done()
         })
         .catch(done)
+    })
+
+    it('returns 503 once signal received', (done) => {
+      execFile('node', ['lib/standalone-tests/terminus.onsignal.fail.js'])
+
+      // let the process start up
+      setTimeout(() => {
+        fetch('http://localhost:8000/health')
+        .then(res => {
+          expect(res.status).to.eql(503)
+          done()
+        })
+        .catch(done)
+      }, 300)
     })
   })
 


### PR DESCRIPTION
Added a `beforeShutdown` as part of this PR, so it makes both testing easier, and enables the consumer to run any operation before the shutdown of the HTTP server starts.

Fixes https://github.com/godaddy/terminus/issues/31