### PR TITLE
fix(lib): support handling multiple servers in one process

### DIFF
--- a/lib/standalone-tests/terminus.multiserver.js
+++ b/lib/standalone-tests/terminus.multiserver.js
@@ -1,0 +1,38 @@
+'use strict'
+const http = require('http')
+const server1 = http.createServer((req, res) => res.end('hello1'))
+const server2 = http.createServer((req, res) => res.end('hello2'))
+const server3 = http.createServer((req, res) => res.end('hello3'))
+
+const terminus = require('../terminus')
+
+terminus(server1, {
+  onSignal: () => {
+    console.log('server1:onSignal')
+    return Promise.resolve()
+  }
+})
+terminus(server2, {
+  onSignal: () => {
+    console.log('server2:onSignal')
+    return Promise.resolve()
+  }
+})
+terminus(server3, {
+  onSignal: () => {
+    console.log('server3:onSignal')
+    return Promise.resolve()
+  }
+})
+
+new Promise((resolve) => {
+  let counter = 3
+  const handle = () => {
+    counter -= 1
+    if (counter <= 0) { resolve() }
+  }
+  server1.listen(8000, handle)
+  server2.listen(8001, handle)
+  server3.listen(8002, handle)
+})
+  .then(() => process.kill(process.pid, 'SIGTERM'))

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -31,13 +31,13 @@ function sendFailure (res) {
   res.end(FAILURE_RESPONSE)
 }
 
-const state = {
+const intialState = {
   isShuttingDown: false
 }
 
 function noop () {}
 
-function decorateWithHealthCheck (server, options) {
+function decorateWithHealthCheck (server, state, options) {
   const { healthChecks, logger } = options
 
   server.listeners('request').forEach((listener) => {
@@ -62,7 +62,7 @@ function decorateWithHealthCheck (server, options) {
   })
 }
 
-function decorateWithSignalHandler (server, options) {
+function decorateWithSignalHandler (server, state, options) {
   const { signals, onSignal, beforeShutdown, onShutdown, timeout, logger } = options
 
   stoppable(server, timeout)
@@ -100,9 +100,10 @@ function terminus (server, options = {}) {
     beforeShutdown = noopResolves,
     logger = noop } = options
   const onSignal = options.onSignal || options.onSigterm || noopResolves
+  const state = { ...intialState }
 
   if (Object.keys(healthChecks).length > 0) {
-    decorateWithHealthCheck(server, {
+    decorateWithHealthCheck(server, state, {
       healthChecks,
       logger
     })
@@ -111,7 +112,7 @@ function terminus (server, options = {}) {
   // push the signal into the array
   // for backwards compatability
   if (!signals.includes(signal)) signals.push(signal)
-  decorateWithSignalHandler(server, {
+  decorateWithSignalHandler(server, state, {
     signals,
     onSignal,
     beforeShutdown,

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -100,7 +100,7 @@ function terminus (server, options = {}) {
     beforeShutdown = noopResolves,
     logger = noop } = options
   const onSignal = options.onSignal || options.onSigterm || noopResolves
-  const state = { ...intialState }
+  const state = Object.assign({}, intialState)
 
   if (Object.keys(healthChecks).length > 0) {
     decorateWithHealthCheck(server, state, {

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -188,4 +188,13 @@ describe('Terminus', () => {
     const result = spawnSync('node', ['lib/standalone-tests/terminus.onshutdown.multiple.js', 'SIGUSR2'])
     expect(result.stdout.toString().trim()).to.eql('on-sigusr2-runs\non-shutdown-runs')
   })
+
+  it('manages multiple servers', () => {
+    const result = spawnSync('node', ['lib/standalone-tests/terminus.multiserver.js'])
+    expect(result.stdout.toString().trim()).to.eql([
+      'server1:onSignal',
+      'server2:onSignal',
+      'server3:onSignal'
+    ].join('\n'))
+  })
 })


### PR DESCRIPTION
Currently, it is not possible to register multiple servers with terminus due to the shared state in the library. This PR creates new state on each call of terminus.