### PR TITLE
Add onSendFailure() callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,14 @@ const options = {
   // cleanup options
   timeout: 1000,                   // [optional = 1000] number of milliseconds before forcefull exiting
   signal,                          // [optional = 'SIGTERM'] what signal to listen for relative to shutdown
-  signals,                          // [optional = []] array of signals to listen for relative to shutdown
+  signals,                         // [optional = []] array of signals to listen for relative to shutdown
   beforeShutdown,                  // [optional] called before the HTTP server starts its shutdown
   onSignal,                        // [optional] cleanup function, returning a promise (used to be onSigterm)
   onShutdown,                      // [optional] called right before exiting
 
   // both
-  logger                           // [optional] logger function to be called with errors
+  logger,                          // [optional] logger function to be called with errors
+  onSendFailure                    // [optional] callback when sending 503 on healthcheck failures
 };
 
 createTerminus(server, options);

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const options = {
 
   // both
   logger,                          // [optional] logger function to be called with errors
-  onSendFailure                    // [optional] callback when sending 503 on healthcheck failures
+  onSendFailure                    // [optional] function to be called before sending 503 on healthcheck failures
 };
 
 createTerminus(server, options);

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -27,7 +27,10 @@ function sendSuccess (res, info) {
   res.end(SUCCESS_RESPONSE)
 }
 
-function sendFailure (res, error) {
+function sendFailure (res, error, onSendFailure) {
+  if (onSendFailure) {
+    onSendFailure()
+  }
   res.statusCode = 503
   res.setHeader('Content-Type', 'application/json')
   if (error) {
@@ -46,14 +49,14 @@ const intialState = {
 function noop () {}
 
 function decorateWithHealthCheck (server, state, options) {
-  const { healthChecks, logger } = options
+  const { healthChecks, logger, onSendFailure } = options
 
   server.listeners('request').forEach((listener) => {
     server.removeListener('request', listener)
     server.on('request', (req, res) => {
       if (healthChecks[req.url]) {
         if (state.isShuttingDown) {
-          return sendFailure(res)
+          return sendFailure(res, null, onSendFailure)
         }
         healthChecks[req.url]()
           .then((info) => {
@@ -61,7 +64,7 @@ function decorateWithHealthCheck (server, state, options) {
           })
           .catch((error) => {
             logger('healthcheck failed', error)
-            sendFailure(res, error.causes)
+            sendFailure(res, error.causes, onSendFailure)
           })
       } else {
         listener(req, res)
@@ -104,6 +107,7 @@ function terminus (server, options = {}) {
     signals = [],
     timeout = 1000,
     healthChecks = {},
+    onSendFailure = noop,
     onShutdown = noopResolves,
     beforeShutdown = noopResolves,
     logger = noop } = options
@@ -113,7 +117,8 @@ function terminus (server, options = {}) {
   if (Object.keys(healthChecks).length > 0) {
     decorateWithHealthCheck(server, state, {
       healthChecks,
-      logger
+      logger,
+      onSendFailure
     })
   }
 

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -119,6 +119,30 @@ describe('Terminus', () => {
         .catch(done)
     })
 
+    it('calls onSendFailure when sending 503', (done) => {
+      let onSendFailureRan = false
+
+      createTerminus(server, {
+        healthChecks: {
+          '/health': () => {
+            return Promise.reject(new Error('failed'))
+          }
+        },
+        onSendFailure: () => {
+          onSendFailureRan = true
+        }
+      })
+      server.listen(8000)
+
+      fetch('http://localhost:8000/health')
+        .then(res => {
+          expect(res.status).to.eql(503)
+          expect(onSendFailureRan).to.eql(true)
+          done()
+        })
+        .catch(done)
+    })
+
     it('includes error on reject', (done) => {
       let onHealthCheckRan = false
 


### PR DESCRIPTION
In the normal lifecycle of Kubernetes pods, we do not want noisy logs when health and readiness checks are called by the operator.

Terminus enables us to ignore these particular transactions thusly (example shown for NewRelic):
```
terminus(httpServer, {
    healthChecks: {
        'readiness': () => new Promise((resolve) => {
            newrelic.setIgnoreTransaction(true);
            resolve();
        }),
    },
});
```

However, after the SIGTERM has been handed out by Kubernetes, our promise is (of course) no longer resolved on subsequent readiness checks that correctly turn 503s, resulting in a spike of error messages on our logging platform (in this case NewRelic).

If the API supported this, we would be set:
```
terminus(httpServer, {
    healthChecks: {
        'readiness': () => new Promise((resolve) => {
            newrelic.setIgnoreTransaction(true);
            resolve();
        }),
    },
    onSendFailure: () => {
        newrelic.setIgnoreTransaction(true);
    },
});
```

This PR adds the necessary `onSendFailure` callback to support this functionality and eliminate noise from observation.

### Why not a promise?
Using a promise would require major refactoring of the architecture of this decorator:
https://github.com/godaddy/terminus/blob/319f66229ea42d681b65d851ee1313c4f55aaffa/lib/terminus.js#L51-L71

I opted for the simplest solution, for a smaller pull request, without introducing major refactors to the architecture of Terminus.

I'm of course open to suggestions on whether this can be improved.