### PR TITLE
Add onSendFailureDuringShutdown callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,14 @@ const options = {
   // cleanup options
   timeout: 1000,                   // [optional = 1000] number of milliseconds before forcefull exiting
   signal,                          // [optional = 'SIGTERM'] what signal to listen for relative to shutdown
-  signals,                          // [optional = []] array of signals to listen for relative to shutdown
+  signals,                         // [optional = []] array of signals to listen for relative to shutdown
   beforeShutdown,                  // [optional] called before the HTTP server starts its shutdown
   onSignal,                        // [optional] cleanup function, returning a promise (used to be onSigterm)
   onShutdown,                      // [optional] called right before exiting
 
   // both
-  logger                           // [optional] logger function to be called with errors
+  logger,                          // [optional] logger function to be called with errors
+  onSendFailure                    // [optional] callback when sending 503 on healthcheck failures
 };
 
 createTerminus(server, options);

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const options = {
 
   // both
   logger,                          // [optional] logger function to be called with errors
-  onSendFailure                    // [optional] function to be called before sending 503 on healthcheck failures
+  onSendFailureDuringShutdown      // [optional] function to be called before sending 503 during shutdowns
 };
 
 createTerminus(server, options);

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const options = {
 
   // both
   logger,                          // [optional] logger function to be called with errors
-  onSendFailure                    // [optional] callback when sending 503 on healthcheck failures
+  onSendFailure                    // [optional] function to be called before sending 503 on healthcheck failures
 };
 
 createTerminus(server, options);

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ const options = {
   beforeShutdown,                  // [optional] called before the HTTP server starts its shutdown
   onSignal,                        // [optional] cleanup function, returning a promise (used to be onSigterm)
   onShutdown,                      // [optional] called right before exiting
-  onSendFailureDuringShutdown,     // [optional] function to be called before sending each 503 during shutdowns
+  onSendFailureDuringShutdown,     // [optional] called before sending each 503 during shutdowns
 
   // both
   logger                           // [optional] logger function to be called with errors

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ const options = {
   beforeShutdown,                  // [optional] called before the HTTP server starts its shutdown
   onSignal,                        // [optional] cleanup function, returning a promise (used to be onSigterm)
   onShutdown,                      // [optional] called right before exiting
+  onSendFailureDuringShutdown,     // [optional] function to be called before sending each 503 during shutdowns
 
   // both
-  logger,                          // [optional] logger function to be called with errors
-  onSendFailureDuringShutdown      // [optional] function to be called before sending 503 during shutdowns
+  logger                           // [optional] logger function to be called with errors
 };
 
 createTerminus(server, options);

--- a/lib/standalone-tests/terminus.onsendfailureduringshutdown.failed-health.js
+++ b/lib/standalone-tests/terminus.onsendfailureduringshutdown.failed-health.js
@@ -1,0 +1,18 @@
+'use strict'
+const http = require('http')
+const server = http.createServer((req, res) => res.end('hello'))
+
+const { createTerminus } = require('../../')
+
+createTerminus(server, {
+  healthChecks: {
+    '/health': () => Promise.reject(new Error('failure'))
+  },
+  onSendFailureDuringShutdown: () => {
+    console.log('onSendFailureDuringShutdown')
+  }
+})
+
+server.listen(8000, () => {
+  setTimeout(() => process.kill(process.pid, 'SIGTERM'), 600)
+})

--- a/lib/standalone-tests/terminus.onsendfailureduringshutdown.failed-health.js
+++ b/lib/standalone-tests/terminus.onsendfailureduringshutdown.failed-health.js
@@ -8,7 +8,7 @@ createTerminus(server, {
   healthChecks: {
     '/health': () => Promise.reject(new Error('failure'))
   },
-  onSendFailureDuringShutdown: () => {
+  onSendFailureDuringShutdown: async () => {
     console.log('onSendFailureDuringShutdown')
   }
 })

--- a/lib/standalone-tests/terminus.onsendfailureduringshutdown.js
+++ b/lib/standalone-tests/terminus.onsendfailureduringshutdown.js
@@ -1,0 +1,23 @@
+'use strict'
+const http = require('http')
+const server = http.createServer((req, res) => res.end('hello'))
+
+const { createTerminus } = require('../../')
+
+createTerminus(server, {
+  healthChecks: {
+    '/health': () => Promise.resolve()
+  },
+  onSendFailureDuringShutdown: () => {
+    console.log('onSendFailureDuringShutdown')
+  },
+  beforeShutdown: () => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 1000)
+    })
+  }
+})
+
+server.listen(8000, () => {
+  process.kill(process.pid, 'SIGTERM')
+})

--- a/lib/standalone-tests/terminus.onsendfailureduringshutdown.js
+++ b/lib/standalone-tests/terminus.onsendfailureduringshutdown.js
@@ -8,7 +8,7 @@ createTerminus(server, {
   healthChecks: {
     '/health': () => Promise.resolve()
   },
-  onSendFailureDuringShutdown: () => {
+  onSendFailureDuringShutdown: async () => {
     console.log('onSendFailureDuringShutdown')
   },
   beforeShutdown: () => {

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -27,9 +27,9 @@ function sendSuccess (res, info) {
   res.end(SUCCESS_RESPONSE)
 }
 
-function sendFailure (res, error, onSendFailure) {
-  if (onSendFailure) {
-    onSendFailure()
+function sendFailure (res, error, onSendFailureDuringShutdown) {
+  if (onSendFailureDuringShutdown) {
+    onSendFailureDuringShutdown()
   }
   res.statusCode = 503
   res.setHeader('Content-Type', 'application/json')
@@ -49,14 +49,14 @@ const intialState = {
 function noop () {}
 
 function decorateWithHealthCheck (server, state, options) {
-  const { healthChecks, logger, onSendFailure } = options
+  const { healthChecks, logger, onSendFailureDuringShutdown } = options
 
   server.listeners('request').forEach((listener) => {
     server.removeListener('request', listener)
     server.on('request', (req, res) => {
       if (healthChecks[req.url]) {
         if (state.isShuttingDown) {
-          return sendFailure(res, null, onSendFailure)
+          return sendFailure(res, null, onSendFailureDuringShutdown)
         }
         healthChecks[req.url]()
           .then((info) => {
@@ -64,7 +64,7 @@ function decorateWithHealthCheck (server, state, options) {
           })
           .catch((error) => {
             logger('healthcheck failed', error)
-            sendFailure(res, error.causes, onSendFailure)
+            sendFailure(res, error.causes)
           })
       } else {
         listener(req, res)
@@ -107,7 +107,7 @@ function terminus (server, options = {}) {
     signals = [],
     timeout = 1000,
     healthChecks = {},
-    onSendFailure = noop,
+    onSendFailureDuringShutdown = noop,
     onShutdown = noopResolves,
     beforeShutdown = noopResolves,
     logger = noop } = options
@@ -118,7 +118,7 @@ function terminus (server, options = {}) {
     decorateWithHealthCheck(server, state, {
       healthChecks,
       logger,
-      onSendFailure
+      onSendFailureDuringShutdown
     })
   }
 

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -110,7 +110,7 @@ function terminus (server, options = {}) {
     signals = [],
     timeout = 1000,
     healthChecks = {},
-    onSendFailureDuringShutdown = noopResolves,
+    onSendFailureDuringShutdown,
     onShutdown = noopResolves,
     beforeShutdown = noopResolves,
     logger = noop } = options

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -27,7 +27,10 @@ function sendSuccess (res, info) {
   res.end(SUCCESS_RESPONSE)
 }
 
-function sendFailure (res, error) {
+function sendFailure (res, error, onSendFailure) {
+  if (onSendFailure) {
+    onSendFailure()
+  }
   res.statusCode = 503
   res.setHeader('Content-Type', 'application/json')
   if (error) {
@@ -46,14 +49,14 @@ const intialState = {
 function noop () {}
 
 function decorateWithHealthCheck (server, state, options) {
-  const { healthChecks, logger } = options
+  const { healthChecks, logger, onSendFailure } = options
 
   server.listeners('request').forEach((listener) => {
     server.removeListener('request', listener)
     server.on('request', (req, res) => {
       if (healthChecks[req.url]) {
         if (state.isShuttingDown) {
-          return sendFailure(res)
+          return sendFailure(res, null, onSendFailure)
         }
         healthChecks[req.url]()
           .then((info) => {
@@ -61,7 +64,7 @@ function decorateWithHealthCheck (server, state, options) {
           })
           .catch((error) => {
             logger('healthcheck failed', error)
-            sendFailure(res, error.causes)
+            sendFailure(res, error.causes, onSendFailure)
           })
       } else {
         listener(req, res)
@@ -104,6 +107,7 @@ function terminus (server, options = {}) {
     signals = [],
     timeout = 1000,
     healthChecks = {},
+    onSendFailure = noop,
     onShutdown = noopResolves,
     beforeShutdown = noopResolves,
     logger = noop } = options
@@ -113,7 +117,8 @@ function terminus (server, options = {}) {
   if (Object.keys(healthChecks).length > 0) {
     decorateWithHealthCheck(server, state, {
       healthChecks,
-      logger
+      logger,
+      onSendFailure
     })
   }
 

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -15,7 +15,9 @@ function noopResolves () {
   return Promise.resolve()
 }
 
-async function sendSuccess (res, info) {
+async function sendSuccess (res, options) {
+  const { info } = options
+
   res.statusCode = 200
   res.setHeader('Content-Type', 'application/json')
   if (info) {
@@ -67,7 +69,7 @@ function decorateWithHealthCheck (server, state, options) {
           logger('healthcheck failed', error)
           return sendFailure(res, { error: error.causes })
         }
-        return sendSuccess(res, info)
+        return sendSuccess(res, { info })
       } else {
         listener(req, res)
       }

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -27,9 +27,9 @@ function sendSuccess (res, info) {
   res.end(SUCCESS_RESPONSE)
 }
 
-function sendFailure (res, error, onSendFailureDuringShutdown) {
+async function sendFailure (res, error, onSendFailureDuringShutdown) {
   if (onSendFailureDuringShutdown) {
-    onSendFailureDuringShutdown()
+    await onSendFailureDuringShutdown()
   }
   res.statusCode = 503
   res.setHeader('Content-Type', 'application/json')
@@ -56,14 +56,16 @@ function decorateWithHealthCheck (server, state, options) {
     server.on('request', async (req, res) => {
       if (healthChecks[req.url]) {
         if (state.isShuttingDown) {
-          return sendFailure(res, null, onSendFailureDuringShutdown)
+          await sendFailure(res, null, onSendFailureDuringShutdown)
+          return
         }
         let info
         try {
           info = await healthChecks[req.url]()
         } catch (error) {
           logger('healthcheck failed', error)
-          return sendFailure(res, error.causes)
+          await sendFailure(res, error.causes)
+          return
         }
         sendSuccess(res, info)
       } else {
@@ -106,7 +108,7 @@ function terminus (server, options = {}) {
     signals = [],
     timeout = 1000,
     healthChecks = {},
-    onSendFailureDuringShutdown = noop,
+    onSendFailureDuringShutdown = noopResolves,
     onShutdown = noopResolves,
     beforeShutdown = noopResolves,
     logger = noop } = options

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -15,7 +15,7 @@ function noopResolves () {
   return Promise.resolve()
 }
 
-function sendSuccess (res, info) {
+async function sendSuccess (res, info) {
   res.statusCode = 200
   res.setHeader('Content-Type', 'application/json')
   if (info) {
@@ -27,7 +27,9 @@ function sendSuccess (res, info) {
   res.end(SUCCESS_RESPONSE)
 }
 
-async function sendFailure (res, error, onSendFailureDuringShutdown) {
+async function sendFailure (res, options) {
+  const { error, onSendFailureDuringShutdown } = options
+
   if (onSendFailureDuringShutdown) {
     await onSendFailureDuringShutdown()
   }
@@ -56,18 +58,16 @@ function decorateWithHealthCheck (server, state, options) {
     server.on('request', async (req, res) => {
       if (healthChecks[req.url]) {
         if (state.isShuttingDown) {
-          await sendFailure(res, null, onSendFailureDuringShutdown)
-          return
+          return sendFailure(res, { onSendFailureDuringShutdown })
         }
         let info
         try {
           info = await healthChecks[req.url]()
         } catch (error) {
           logger('healthcheck failed', error)
-          await sendFailure(res, error.causes)
-          return
+          return sendFailure(res, { error: error.causes })
         }
-        sendSuccess(res, info)
+        return sendSuccess(res, info)
       } else {
         listener(req, res)
       }

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -216,6 +216,37 @@ describe('Terminus', () => {
           })
       }, 300)
     })
+
+    it('does NOT call onSendFailureDuringShutdown when sending 503 during failed healthcheck', (done) => {
+      let responseAssertionsComplete = false
+
+      // We're only truly finished when the response has been analyzed and the process is completely
+      // finished, freeing up port 8000 for future tests
+      const finished = () => {
+        expect(responseAssertionsComplete).to.eql(true)
+        done()
+      }
+
+      execFile('node', ['lib/standalone-tests/terminus.onsendfailureduringshutdown.failed-health.js'],
+        (error, stdout) => {
+          // Here, we expect NOT to see "onSendFailureDuringShutdown"
+          expect(stdout).to.eql('')
+          finished()
+
+          if (error) {
+            throw error
+          }
+        })
+
+      // let the process start up
+      setTimeout(() => {
+        fetch('http://localhost:8000/health')
+          .then(res => {
+            expect(res.status).to.eql(503)
+            responseAssertionsComplete = true
+          })
+      }, 300)
+    })
   })
 
   it('runs onSignal when getting the SIGTERM signal', () => {

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -119,30 +119,6 @@ describe('Terminus', () => {
         .catch(done)
     })
 
-    it('calls onSendFailure when sending 503', (done) => {
-      let onSendFailureRan = false
-
-      createTerminus(server, {
-        healthChecks: {
-          '/health': () => {
-            return Promise.reject(new Error('failed'))
-          }
-        },
-        onSendFailure: () => {
-          onSendFailureRan = true
-        }
-      })
-      server.listen(8000)
-
-      fetch('http://localhost:8000/health')
-        .then(res => {
-          expect(res.status).to.eql(503)
-          expect(onSendFailureRan).to.eql(true)
-          done()
-        })
-        .catch(done)
-    })
-
     it('includes error on reject', (done) => {
       let onHealthCheckRan = false
 
@@ -184,16 +160,60 @@ describe('Terminus', () => {
     })
 
     it('returns 503 once signal received', (done) => {
-      execFile('node', ['lib/standalone-tests/terminus.onsignal.fail.js'])
+      let responseAssertionsComplete = false
+
+      // We're only truly finished when the response has been analyzed and the process is completely
+      // finished, freeing up port 8000 for future tests
+      const finished = () => {
+        expect(responseAssertionsComplete).to.eql(true)
+        done()
+      }
+
+      execFile('node', ['lib/standalone-tests/terminus.onsignal.fail.js'], (error) => {
+        finished()
+
+        if (error) {
+          throw error
+        }
+      })
 
       // let the process start up
       setTimeout(() => {
         fetch('http://localhost:8000/health')
           .then(res => {
             expect(res.status).to.eql(503)
-            done()
+            responseAssertionsComplete = true
           })
-          .catch(done)
+      }, 300)
+    })
+
+    it('calls onSendFailureDuringShutdown when sending 503 during shutdown', (done) => {
+      let responseAssertionsComplete = false
+
+      // We're only truly finished when the response has been analyzed and the process is completely
+      // finished, freeing up port 8000 for future tests
+      const finished = () => {
+        expect(responseAssertionsComplete).to.eql(true)
+        done()
+      }
+
+      execFile('node', ['lib/standalone-tests/terminus.onsendfailureduringshutdown.js'],
+        (error, stdout) => {
+          expect(stdout).to.eql('onSendFailureDuringShutdown\n')
+          finished()
+
+          if (error) {
+            throw error
+          }
+        })
+
+      // let the process start up
+      setTimeout(() => {
+        fetch('http://localhost:8000/health')
+          .then(res => {
+            expect(res.status).to.eql(503)
+            responseAssertionsComplete = true
+          })
       }, 300)
     })
   })

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -164,15 +164,11 @@ describe('Terminus', () => {
 
       // We're only truly finished when the response has been analyzed and the forked http process has exited,
       // freeing up port 8000 for future tests
-      const finished = () => {
-        expect(responseAssertionsComplete).to.eql(true)
-        done()
-      }
-
       execFile('node', ['lib/standalone-tests/terminus.onsendfailureduringshutdown.js'],
         (error, stdout) => {
           expect(stdout).to.eql('onSendFailureDuringShutdown\n')
-          finished()
+          expect(responseAssertionsComplete).to.eql(true)
+          done()
 
           if (error) {
             throw error
@@ -194,16 +190,12 @@ describe('Terminus', () => {
 
       // We're only truly finished when the response has been analyzed and the forked http process has exited,
       // freeing up port 8000 for future tests
-      const finished = () => {
-        expect(responseAssertionsComplete).to.eql(true)
-        done()
-      }
-
       execFile('node', ['lib/standalone-tests/terminus.onsendfailureduringshutdown.failed-health.js'],
         (error, stdout) => {
           // Here, we expect NOT to see "onSendFailureDuringShutdown"
           expect(stdout).to.eql('')
-          finished()
+          expect(responseAssertionsComplete).to.eql(true)
+          done()
 
           if (error) {
             throw error

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -140,13 +140,9 @@ describe('Terminus', () => {
 
       // We're only truly finished when the response has been analyzed and the forked http process has exited,
       // freeing up port 8000 for future tests
-      execFile('node', ['lib/standalone-tests/terminus.onsignal.fail.js'], (error) => {
+      execFile('node', ['lib/standalone-tests/terminus.onsignal.fail.js'], () => {
         expect(responseAssertionsComplete).to.eql(true)
         done()
-
-        if (error) {
-          throw error
-        }
       })
 
       // let the process start up
@@ -166,13 +162,13 @@ describe('Terminus', () => {
       // freeing up port 8000 for future tests
       execFile('node', ['lib/standalone-tests/terminus.onsendfailureduringshutdown.js'],
         (error, stdout) => {
+          if (error) {
+            // Do nothing; we expect this to be an error exit code because we are issuing a SIGTERM
+            // (This if statement is required due to `handle-callback-err` rule.)
+          }
           expect(stdout).to.eql('onSendFailureDuringShutdown\n')
           expect(responseAssertionsComplete).to.eql(true)
           done()
-
-          if (error) {
-            throw error
-          }
         })
 
       // let the process start up
@@ -192,14 +188,14 @@ describe('Terminus', () => {
       // freeing up port 8000 for future tests
       execFile('node', ['lib/standalone-tests/terminus.onsendfailureduringshutdown.failed-health.js'],
         (error, stdout) => {
+          if (error) {
+            // Do nothing; we expect this to be an error exit code because we are issuing a SIGTERM
+            // (This if statement is required due to `handle-callback-err` rule.)
+          }
           // Here, we expect NOT to see "onSendFailureDuringShutdown"
           expect(stdout).to.eql('')
           expect(responseAssertionsComplete).to.eql(true)
           done()
-
-          if (error) {
-            throw error
-          }
         })
 
       // let the process start up

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -162,8 +162,8 @@ describe('Terminus', () => {
     it('returns 503 once signal received', (done) => {
       let responseAssertionsComplete = false
 
-      // We're only truly finished when the response has been analyzed and the process is completely
-      // finished, freeing up port 8000 for future tests
+      // We're only truly finished when the response has been analyzed and the forked http process has exited,
+      // freeing up port 8000 for future tests
       const finished = () => {
         expect(responseAssertionsComplete).to.eql(true)
         done()
@@ -190,8 +190,8 @@ describe('Terminus', () => {
     it('calls onSendFailureDuringShutdown when sending 503 during shutdown', (done) => {
       let responseAssertionsComplete = false
 
-      // We're only truly finished when the response has been analyzed and the process is completely
-      // finished, freeing up port 8000 for future tests
+      // We're only truly finished when the response has been analyzed and the forked http process has exited,
+      // freeing up port 8000 for future tests
       const finished = () => {
         expect(responseAssertionsComplete).to.eql(true)
         done()
@@ -220,8 +220,8 @@ describe('Terminus', () => {
     it('does NOT call onSendFailureDuringShutdown when sending 503 during failed healthcheck', (done) => {
       let responseAssertionsComplete = false
 
-      // We're only truly finished when the response has been analyzed and the process is completely
-      // finished, freeing up port 8000 for future tests
+      // We're only truly finished when the response has been analyzed and the forked http process has exited,
+      // freeing up port 8000 for future tests
       const finished = () => {
         expect(responseAssertionsComplete).to.eql(true)
         done()

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -119,6 +119,30 @@ describe('Terminus', () => {
         .catch(done)
     })
 
+    it('calls onSendFailure when sending 503', (done) => {
+      let onSendFailureRan = false
+
+      createTerminus(server, {
+        healthChecks: {
+          '/health': () => {
+            return Promise.reject(new Error('failed'))
+          }
+        },
+        onSendFailure: () => {
+          onSendFailureRan = true
+        }
+      })
+      server.listen(8000)
+
+      fetch('http://localhost:8000/health')
+        .then(res => {
+          expect(res.status).to.eql(503)
+          expect(onSendFailureRan).to.eql(true)
+          done()
+        })
+        .catch(done)
+    })
+
     it('includes error on reject', (done) => {
       let onHealthCheckRan = false
 

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -140,7 +140,8 @@ describe('Terminus', () => {
 
       // We're only truly finished when the response has been analyzed and the forked http process has exited,
       // freeing up port 8000 for future tests
-      execFile('node', ['lib/standalone-tests/terminus.onsignal.fail.js'], () => {
+      execFile('node', ['lib/standalone-tests/terminus.onsignal.fail.js'], (error) => {
+        expect(error.signal).to.eql('SIGINT')
         expect(responseAssertionsComplete).to.eql(true)
         done()
       })
@@ -162,10 +163,7 @@ describe('Terminus', () => {
       // freeing up port 8000 for future tests
       execFile('node', ['lib/standalone-tests/terminus.onsendfailureduringshutdown.js'],
         (error, stdout) => {
-          if (error) {
-            // Do nothing; we expect this to be an error exit code because we are issuing a SIGTERM
-            // (This if statement is required due to `handle-callback-err` rule.)
-          }
+          expect(error.signal).to.eql('SIGTERM')
           expect(stdout).to.eql('onSendFailureDuringShutdown\n')
           expect(responseAssertionsComplete).to.eql(true)
           done()
@@ -188,10 +186,7 @@ describe('Terminus', () => {
       // freeing up port 8000 for future tests
       execFile('node', ['lib/standalone-tests/terminus.onsendfailureduringshutdown.failed-health.js'],
         (error, stdout) => {
-          if (error) {
-            // Do nothing; we expect this to be an error exit code because we are issuing a SIGTERM
-            // (This if statement is required due to `handle-callback-err` rule.)
-          }
+          expect(error.signal).to.eql('SIGTERM')
           // Here, we expect NOT to see "onSendFailureDuringShutdown"
           expect(stdout).to.eql('')
           expect(responseAssertionsComplete).to.eql(true)

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -140,13 +140,9 @@ describe('Terminus', () => {
 
       // We're only truly finished when the response has been analyzed and the forked http process has exited,
       // freeing up port 8000 for future tests
-      const finished = () => {
+      execFile('node', ['lib/standalone-tests/terminus.onsignal.fail.js'], (error) => {
         expect(responseAssertionsComplete).to.eql(true)
         done()
-      }
-
-      execFile('node', ['lib/standalone-tests/terminus.onsignal.fail.js'], (error) => {
-        finished()
 
         if (error) {
           throw error


### PR DESCRIPTION
In the normal lifecycle of Kubernetes pods, we do not want noisy logs when health and readiness checks are called by the operator.

Terminus enables us to ignore these particular transactions thusly (example shown for NewRelic):
```
terminus(httpServer, {
    healthChecks: {
        '/readiness': () => new Promise((resolve) => {
            newrelic.setIgnoreTransaction(true);
            resolve();
        }),
    },
});
```

However, after the SIGTERM has been handed out by Kubernetes, and a graceful shutdown has began, our promise is (of course) no longer resolved on subsequent readiness checks that correctly turn 503s, resulting in a spike of error messages on our logging platform (in this case NewRelic).

I'm proposing that the API support custom logic to be called on these normal, expected 503s on readiness checks, to enable ignoring these "normal" failures:
```
terminus(httpServer, {
    healthChecks: {
        '/readiness': () => new Promise((resolve) => {
            newrelic.setIgnoreTransaction(true);
            resolve();
        }),
    },
    onSendFailureDuringShutdown: () => {
        newrelic.setIgnoreTransaction(true);
    },
});
```

This PR adds the necessary `onSendFailureDuringShutdown` callback to support this functionality and eliminate noise from observation.

### Why not a promise?
Using a promise would require major refactoring of the architecture of this decorator:
https://github.com/godaddy/terminus/blob/319f66229ea42d681b65d851ee1313c4f55aaffa/lib/terminus.js#L51-L71

I opted for the simplest solution, for a smaller pull request, without introducing major refactors to the architecture of Terminus.

I'm of course open to suggestions on whether this can be improved.

Note that I changed this existing test:
https://github.com/godaddy/terminus/blob/319f66229ea42d681b65d851ee1313c4f55aaffa/lib/terminus.spec.js#L162-L174

Before my change, this test would complete, but the http server was still running and holding up port 8000. I changed the test to guarantee that the http server process is gone before the test completes, allowing me to use port 8000 on the subsequent tests I added.