### PR TITLE
fix: do not send multiple response for the same request

### DIFF
--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -62,27 +62,38 @@ function noop () {}
 function decorateWithHealthCheck (server, state, options) {
   const { healthChecks, logger, onSendFailureDuringShutdown, caseInsensitive } = options
 
-  server.listeners('request').forEach((listener) => {
-    server.removeListener('request', listener)
-    server.on('request', async (req, res) => {
+  let hasSetHandler = false
+  const createHandler = (listener) => {
+    const check = hasSetHandler ? () => {} : async (healthCheck, res) => {
+      if (state.isShuttingDown) {
+        return sendFailure(res, { onSendFailureDuringShutdown })
+      }
+      let info
+      try {
+        info = await healthCheck()
+      } catch (error) {
+        logger('healthcheck failed', error)
+        return sendFailure(res, { error: error.causes })
+      }
+      return sendSuccess(res, { info, verbatim: healthChecks.verbatim })
+    }
+
+    hasSetHandler = true
+
+    return async (req, res) => {
       const url = caseInsensitive ? req.url.toLowerCase() : req.url
       const healthCheck = healthChecks[url]
       if (healthCheck) {
-        if (state.isShuttingDown) {
-          return sendFailure(res, { onSendFailureDuringShutdown })
-        }
-        let info
-        try {
-          info = await healthCheck()
-        } catch (error) {
-          logger('healthcheck failed', error)
-          return sendFailure(res, { error: error.causes })
-        }
-        return sendSuccess(res, { info, verbatim: healthChecks.verbatim })
+        return check(healthCheck, res)
       } else {
         listener(req, res)
       }
-    })
+    }
+  }
+
+  server.listeners('request').forEach((listener) => {
+    server.removeListener('request', listener)
+    server.on('request', createHandler(listener))
   })
 }
 

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -102,6 +102,35 @@ describe('Terminus', () => {
       expect(onHealthCheckRan).to.eql(true)
     })
 
+    it('do not send multiple responses for the same request', async () => {
+      let healthCheckRanTimes = 0
+      let hasHandlerCalled = false
+      let hasUnhandledRejection = false
+
+      process.once('unhandledRejection', () => {
+        hasUnhandledRejection = true;
+      })
+
+      server.on('request', () => {
+        hasHandlerCalled = true
+      })
+
+      createTerminus(server, {
+        healthChecks: {
+          '/healthCheck': () => {
+            healthCheckRanTimes++
+            return Promise.resolve()
+          }
+        },
+      })
+      server.listen(8000)
+
+      await fetch('http://localhost:8000/healthCheck')
+      expect(hasUnhandledRejection).to.eql(false)
+      expect(healthCheckRanTimes).to.eql(1)
+      expect(hasHandlerCalled).to.eql(false)
+    })
+
     it('includes info on resolve', async () => {
       let onHealthCheckRan = false
 


### PR DESCRIPTION
Previously, if the server has several 'request' handlers then healthCheck function will be called several times leading to promise 'unhandledRejection' with error 'Cannot set headers after they are sent to the client'

This pr will set response only once, and for other 'request' handlers it will ignore 'healthCheck' functionality