### PR TITLE
Fixes TS typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,7 +8,9 @@ declare module "@godaddy/terminus" {
   }
 
   export type HealthCheckMap = {
-    verbatim?: boolean;
+    [key: string]: HealthCheck | boolean;
+  } | {
+    verbatim: boolean
     [key: string]: HealthCheck | boolean;
   }
 


### PR DESCRIPTION
Issue: #122
 
TS compilation fails with 
```
TS2411: Property 'verbatim' of type 'boolean | undefined' is not assignable to string index type 'boolean | HealthCheck'
```
---
```
export type HealthCheckMap = {
    verbatim?: boolean;
    [key: string]: HealthCheck | boolean;
  }
```
`[key: string]: HealthCheck | boolean` enforces `verbatim`  type to be `boolean` or `HealthCheck`, conficting with it's current type `boolean | undefined`.

Easiest solution to make this compile again without updating the API is to update `HealthCheckMap` definition.
