### PR TITLE
fix: Do not publish examples

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+.vscode
+*.log
+.nyc_output
+.idea
+example
+*.spec.js
+.eslintrc
+.travis.yml


### PR DESCRIPTION
Closes: https://github.com/godaddy/terminus/issues/158

Currently, the `example` directory is published in the npm package. This results in `godaddy/terminus` being flagged with `CVE-2019-17426` since the example included installs `mongoose:1.0.0`. A simple solution to this is to add `example` to a `.npmignore`

Publish dry-run:
```
> npm publish --dry-run
npm notice
npm notice 📦  @godaddy/terminus@0.0.0-development
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 187B  index.js
npm notice 208B  lib/terminus-error.js
npm notice 4.3kB lib/terminus.js
npm notice 920B  lib/standalone-tests/terminus.multiserver.js
npm notice 408B  lib/standalone-tests/terminus.onmultiple.js
npm notice 453B  lib/standalone-tests/terminus.onsendfailureduringshutdown.failed-health.js
npm notice 519B  lib/standalone-tests/terminus.onsendfailureduringshutdown.js
npm notice 522B  lib/standalone-tests/terminus.onshutdown.multiple.js
npm notice 442B  lib/standalone-tests/terminus.onshutdown.sigint.js
npm notice 404B  lib/standalone-tests/terminus.onshutdown.sigterm.js
npm notice 444B  lib/standalone-tests/terminus.onshutdown.sigusr2.js
npm notice 379B  lib/standalone-tests/terminus.onsigint.js
npm notice 461B  lib/standalone-tests/terminus.onsignal.fail.js
npm notice 341B  lib/standalone-tests/terminus.onsigterm.js
npm notice 381B  lib/standalone-tests/terminus.onsigusr2.js
npm notice 1.2kB package.json
npm notice 5.8kB README.md
npm notice 439B  typings/express.test.ts
npm notice 899B  typings/index.d.ts
npm notice 931B  typings/index.test.ts
npm notice 388B  typings/koa.test.ts
npm notice === Tarball Details ===
npm notice name:          @godaddy/terminus
npm notice version:       0.0.0-development
npm notice package size:  6.5 kB
npm notice unpacked size: 21.1 kB
npm notice shasum:        5db7df6cc9571d105de29bbb4981248a3d89ce14
npm notice integrity:     sha512-MiHldn5xow6Dc[...]Z7YakG73wGUhA==
npm notice total files:   22
npm notice
```