### PR TITLE
feat(shutdown): sendFailuresDuringShutdown flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ const options = {
   timeout: 1000,                   // [optional = 1000] number of milliseconds before forceful exiting
   signal,                          // [optional = 'SIGTERM'] what signal to listen for relative to shutdown
   signals,                         // [optional = []] array of signals to listen for relative to shutdown
+  sendFailuresDuringShutdown,      // [optional = true] whether or not to send failure (503) during shutdown
   beforeShutdown,                  // [optional] called before the HTTP server starts its shutdown
   onSignal,                        // [optional] cleanup function, returning a promise (used to be onSigterm)
   onShutdown,                      // [optional] called right before exiting

--- a/lib/standalone-tests/terminus.nofailuresduringshutdown.js
+++ b/lib/standalone-tests/terminus.nofailuresduringshutdown.js
@@ -1,0 +1,24 @@
+'use strict'
+const http = require('http')
+const server = http.createServer((req, res) => res.end('hello'))
+
+const { createTerminus } = require('../../')
+
+createTerminus(server, {
+  healthChecks: {
+    '/health': () => Promise.resolve()
+  },
+  sendFailuresDuringShutdown: false,
+  onSendFailureDuringShutdown: async () => {
+    console.log('onSendFailureDuringShutdown')
+  },
+  beforeShutdown: () => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 1000)
+    })
+  }
+})
+
+server.listen(8000, () => {
+  process.kill(process.pid, 'SIGTERM')
+})

--- a/lib/standalone-tests/terminus.onsignal.nofail.js
+++ b/lib/standalone-tests/terminus.onsignal.nofail.js
@@ -1,0 +1,23 @@
+'use strict'
+const http = require('http')
+const server = http.createServer((req, res) => res.end('hello'))
+
+const { createTerminus } = require('../../')
+const SIGNAL = 'SIGINT'
+
+createTerminus(server, {
+  healthChecks: {
+    '/health': () => Promise.resolve()
+  },
+  sendFailuresDuringShutdown: false,
+  signal: SIGNAL,
+  beforeShutdown: () => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 1000)
+    })
+  }
+})
+
+server.listen(8000, () => {
+  process.kill(process.pid, SIGNAL)
+})

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -58,14 +58,14 @@ const intialState = {
 function noop () {}
 
 function decorateWithHealthCheck (server, state, options) {
-  const { healthChecks, logger, onSendFailureDuringShutdown, caseInsensitive } = options
+  const { healthChecks, logger, onSendFailureDuringShutdown, sendFailuresDuringShutdown, caseInsensitive } = options
 
   let hasSetHandler = false
   const createHandler = (listener) => {
     const check = hasSetHandler
       ? () => {}
       : async (healthCheck, res) => {
-        if (state.isShuttingDown) {
+        if (state.isShuttingDown && sendFailuresDuringShutdown) {
           return sendFailure(res, { onSendFailureDuringShutdown })
         }
         let info
@@ -142,6 +142,7 @@ function terminus (server, options = {}) {
     signals = [],
     timeout = 1000,
     healthChecks = {},
+    sendFailuresDuringShutdown = true,
     onSendFailureDuringShutdown,
     onShutdown = noopResolves,
     beforeShutdown = noopResolves,
@@ -155,6 +156,7 @@ function terminus (server, options = {}) {
     decorateWithHealthCheck(server, state, {
       healthChecks,
       logger,
+      sendFailuresDuringShutdown,
       onSendFailureDuringShutdown,
       caseInsensitive
     })

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -323,6 +323,50 @@ describe('Terminus', () => {
     })
   })
 
+  it('does not return 503 once signal received if `sendFailuresDuringShutdown` is `false`', (done) => {
+    let responseAssertionsComplete = false
+
+    // We're only truly finished when the response has been analyzed and the forked http process has exited,
+    // freeing up port 8000 for future tests
+    execFile('node', ['lib/standalone-tests/terminus.onsignal.nofail.js'], (error) => {
+      expect(error.signal).to.eql('SIGINT')
+      expect(responseAssertionsComplete).to.eql(true)
+      done()
+    })
+
+    // let the process start up
+    setTimeout(() => {
+      fetch('http://localhost:8000/health')
+        .then(res => {
+          expect(res.status).to.eql(200)
+          responseAssertionsComplete = true
+        })
+    }, 300)
+  })
+
+  it('does not call onSendFailureDuringShutdown if `sendFailuresDuringShutdown` is `false`', (done) => {
+    let responseAssertionsComplete = false
+
+    // We're only truly finished when the response has been analyzed and the forked http process has exited,
+    // freeing up port 8000 for future tests
+    execFile('node', ['lib/standalone-tests/terminus.nofailuresduringshutdown.js'],
+      (error, stdout) => {
+        expect(error.signal).to.eql('SIGTERM')
+        expect(stdout).to.eql('')
+        expect(responseAssertionsComplete).to.eql(true)
+        done()
+      })
+
+    // let the process start up
+    setTimeout(() => {
+      fetch('http://localhost:8000/health')
+        .then(res => {
+          expect(res.status).to.eql(200)
+          responseAssertionsComplete = true
+        })
+    }, 300)
+  })
+
   it('runs onSignal when getting the SIGTERM signal', () => {
     const result = spawnSync('node', ['lib/standalone-tests/terminus.onsigterm.js'])
     expect(result.stdout.toString().trim()).to.eql('on-sigterm-runs')

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -19,6 +19,7 @@ declare module "@godaddy/terminus" {
     timeout?: number;
     signal?: string;
     signals?: string[];
+    sendFailuresDuringShutdown?: boolean;
     onSignal?: () => Promise<any>;
     onSendFailureDuringShutdown?: () => Promise<any>;
     onShutdown?: () => Promise<any>;


### PR DESCRIPTION
Adds new boolean flag, `sendFailuresDuringShutdown`.
If set to `false`, health check will continue checking and responding while
shutting down, instead of sending 503s once it receives a signal.

Defaults to `true`, maintaining current behavior as the default.

Fixes #112
