### PR TITLE
Support passing error objects to HealthCheckError

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ const options = {
   // health check options
   healthChecks: {
     '/healthcheck': healthCheck,    // a function returning a promise indicating service health,
-    verbatim: true // [optional = false] use object returned from /healthcheck verbatim in response
+    verbatim: true, // [optional = false] use object returned from /healthcheck verbatim in response,
+    __unsafeExposeStackTraces: true // [optional = false] return stack traces in error response if healthchecks throw errors
   },
   caseInsensitive, // [optional] whether given health checks routes are case insensitive (defaults to false)
 

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -15,20 +15,6 @@ function noopResolves () {
   return Promise.resolve()
 }
 
-function replaceErrors (key, value) {
-  if (value instanceof Error) {
-    const error = {}
-
-    Object.getOwnPropertyNames(value).forEach(function (key) {
-      error[key] = value[key]
-    })
-
-    return error
-  }
-
-  return value
-}
-
 async function sendSuccess (res, { info, verbatim }) {
   res.statusCode = 200
   res.setHeader('Content-Type', 'application/json')
@@ -48,7 +34,22 @@ async function sendSuccess (res, { info, verbatim }) {
 }
 
 async function sendFailure (res, options) {
-  const { error, onSendFailureDuringShutdown } = options
+  const { error, onSendFailureDuringShutdown, exposeStackTraces } = options
+
+  function replaceErrors (_, value) {
+    if (value instanceof Error) {
+      const error = {}
+
+      Object.getOwnPropertyNames(value).forEach(function (key) {
+        if (exposeStackTraces !== true && key === 'stack') return
+        error[key] = value[key]
+      })
+
+      return error
+    }
+
+    return value
+  }
 
   if (onSendFailureDuringShutdown) {
     await onSendFailureDuringShutdown()
@@ -87,7 +88,7 @@ function decorateWithHealthCheck (server, state, options) {
           info = await healthCheck()
         } catch (error) {
           logger('healthcheck failed', error)
-          return sendFailure(res, { error: error.causes })
+          return sendFailure(res, { error: error.causes, exposeStackTraces: healthChecks.__unsafeExposeStackTraces })
         }
         return sendSuccess(res, { info, verbatim: healthChecks.verbatim })
       }

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -15,6 +15,20 @@ function noopResolves () {
   return Promise.resolve()
 }
 
+function replaceErrors (key, value) {
+  if (value instanceof Error) {
+    const error = {}
+
+    Object.getOwnPropertyNames(value).forEach(function (key) {
+      error[key] = value[key]
+    })
+
+    return error
+  }
+
+  return value
+}
+
 async function sendSuccess (res, { info, verbatim }) {
   res.statusCode = 200
   res.setHeader('Content-Type', 'application/json')
@@ -46,7 +60,7 @@ async function sendFailure (res, options) {
       status: 'error',
       error: error,
       details: error
-    }))
+    }, replaceErrors))
   }
   res.end(FAILURE_RESPONSE)
 }

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -254,42 +254,78 @@ describe('Terminus', () => {
       })
     })
 
-    it('includes error on reject (Error objects)', async () => {
-      let onHealthCheckRan = false
+    describe('includes error on reject (Error objects)', async () => {
 
       const errors = [
         new Error('test error 1'),
         new Error('test error 2')
       ]
 
-      createTerminus(server, {
-        healthChecks: {
-          '/health': () => {
-            onHealthCheckRan = true
-            const myError = new HealthCheckError('failed', errors)
-            return Promise.reject(myError)
+      it('does not include stack traces by default', async () => {
+        let onHealthCheckRan = false
+        createTerminus(server, {
+          healthChecks: {
+            '/health': () => {
+              onHealthCheckRan = true
+              const myError = new HealthCheckError('failed', errors)
+              return Promise.reject(myError)
+            }
           }
-        }
+        })
+
+        server.listen(8000)
+
+        const res = await fetch('http://localhost:8000/health')
+        expect(res.status).to.eql(503)
+        expect(onHealthCheckRan).to.eql(true)
+        const json = await res.json()
+
+        const errorMessages = [{
+          message: errors[0].message
+        }, {
+          message: errors[1].message
+        }]
+
+        expect(json).to.deep.eql({
+          status: 'error',
+          error: errorMessages,
+          details: errorMessages
+        })
       })
-      server.listen(8000)
 
-      const res = await fetch('http://localhost:8000/health')
-      expect(res.status).to.eql(503)
-      expect(onHealthCheckRan).to.eql(true)
-      const json = await res.json()
+      it('includes stack traces if __unsafeExposeStackTraces is set', async () => {
+        let onHealthCheckRan = false
+        createTerminus(server, {
+          healthChecks: {
+            '/health': () => {
+              onHealthCheckRan = true
+              const myError = new HealthCheckError('failed', errors)
+              return Promise.reject(myError)
+            },
+            __unsafeExposeStackTraces: true
+          }
+        })
 
-      const errorMessages = [{
-        message: errors[0].message,
-        stack: errors[0].stack.toString()
-      }, {
-        message: errors[1].message,
-        stack: errors[1].stack.toString()
-      }]
+        server.listen(8000)
 
-      expect(json).to.deep.eql({
-        status: 'error',
-        error: errorMessages,
-        details: errorMessages
+        const res = await fetch('http://localhost:8000/health')
+        expect(res.status).to.eql(503)
+        expect(onHealthCheckRan).to.eql(true)
+        const json = await res.json()
+
+        const errorMessages = [{
+          message: errors[0].message,
+          stack: errors[0].stack.toString()
+        }, {
+          message: errors[1].message,
+          stack: errors[1].stack.toString()
+        }]
+
+        expect(json).to.deep.eql({
+          status: 'error',
+          error: errorMessages,
+          details: errorMessages
+        })
       })
     })
 

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -216,53 +216,53 @@ describe('Terminus', () => {
       expect(loggerRan).to.eql(true)
     })
 
-    it('includes error on reject (custom errors)', async () => {
-      let onHealthCheckRan = false
-
-      createTerminus(server, {
-        healthChecks: {
-          '/health': () => {
-            onHealthCheckRan = true
-            const myError = new HealthCheckError('failed', {
-              fornite: 'client down',
-              redis: {
-                disk: 100
-              }
-            })
-            return Promise.reject(myError)
-          }
-        }
-      })
-      server.listen(8000)
-
-      const res = await fetch('http://localhost:8000/health')
-      expect(res.status).to.eql(503)
-      expect(onHealthCheckRan).to.eql(true)
-      const json = await res.json()
-      expect(json).to.deep.eql({
-        status: 'error',
-        error: {
-          fornite: 'client down',
-          redis: {
-            disk: 100
-          }
-        },
-        details: {
-          fornite: 'client down',
-          redis: {
-            disk: 100
-          }
-        }
-      })
-    })
-
-    describe('includes error on reject (Error objects)', async () => {
+    describe('includes error on reject', async () => {
       const errors = [
         new Error('test error 1'),
         new Error('test error 2')
       ]
 
-      it('does not include stack traces by default', async () => {
+      it('Returns custom objects as errors', async () => {
+        let onHealthCheckRan = false
+
+        createTerminus(server, {
+          healthChecks: {
+            '/health': () => {
+              onHealthCheckRan = true
+              const myError = new HealthCheckError('failed', {
+                fornite: 'client down',
+                redis: {
+                  disk: 100
+                }
+              })
+              return Promise.reject(myError)
+            }
+          }
+        })
+        server.listen(8000)
+
+        const res = await fetch('http://localhost:8000/health')
+        expect(res.status).to.eql(503)
+        expect(onHealthCheckRan).to.eql(true)
+        const json = await res.json()
+        expect(json).to.deep.eql({
+          status: 'error',
+          error: {
+            fornite: 'client down',
+            redis: {
+              disk: 100
+            }
+          },
+          details: {
+            fornite: 'client down',
+            redis: {
+              disk: 100
+            }
+          }
+        })
+      })
+
+      it('Returns error objects as errors and does not include stack traces by default', async () => {
         let onHealthCheckRan = false
         createTerminus(server, {
           healthChecks: {
@@ -294,7 +294,7 @@ describe('Terminus', () => {
         })
       })
 
-      it('includes stack traces if __unsafeExposeStackTraces is set', async () => {
+      it('Returns error objects as errors and includes stack traces if __unsafeExposeStackTraces is set', async () => {
         let onHealthCheckRan = false
         createTerminus(server, {
           healthChecks: {

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -8,6 +8,8 @@ const fetch = require('node-fetch')
 const { createTerminus } = require('./terminus')
 const { HealthCheckError } = require('./terminus-error')
 
+process.setMaxListeners(100) // Removes node's built in max listeners warning while we're testing
+
 describe('Terminus', () => {
   let server
 
@@ -255,7 +257,6 @@ describe('Terminus', () => {
     })
 
     describe('includes error on reject (Error objects)', async () => {
-
       const errors = [
         new Error('test error 1'),
         new Error('test error 2')

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -214,7 +214,7 @@ describe('Terminus', () => {
       expect(loggerRan).to.eql(true)
     })
 
-    it('includes error on reject', async () => {
+    it('includes error on reject (custom errors)', async () => {
       let onHealthCheckRan = false
 
       createTerminus(server, {
@@ -251,6 +251,45 @@ describe('Terminus', () => {
             disk: 100
           }
         }
+      })
+    })
+
+    it('includes error on reject (Error objects)', async () => {
+      let onHealthCheckRan = false
+
+      const errors = [
+        new Error('test error 1'),
+        new Error('test error 2')
+      ]
+
+      createTerminus(server, {
+        healthChecks: {
+          '/health': () => {
+            onHealthCheckRan = true
+            const myError = new HealthCheckError('failed', errors)
+            return Promise.reject(myError)
+          }
+        }
+      })
+      server.listen(8000)
+
+      const res = await fetch('http://localhost:8000/health')
+      expect(res.status).to.eql(503)
+      expect(onHealthCheckRan).to.eql(true)
+      const json = await res.json()
+
+      const errorMessages = [{
+        message: errors[0].message,
+        stack: errors[0].stack.toString()
+      }, {
+        message: errors[1].message,
+        stack: errors[1].stack.toString()
+      }]
+
+      expect(json).to.deep.eql({
+        status: 'error',
+        error: errorMessages,
+        details: errorMessages
       })
     })
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,9 +8,8 @@ declare module "@godaddy/terminus" {
   }
 
   export type HealthCheckMap = {
-    [key: string]: HealthCheck | boolean;
-  } | {
-    verbatim: boolean
+    verbatim?: boolean
+    __unsafeExposeStackTraces?: boolean;
     [key: string]: HealthCheck | boolean;
   }
 


### PR DESCRIPTION
Reading through the README, one would assume that by using the custom `HealthCheckError` class we'd be able to pass errors caught in the `Promise.all` and see these returned in the result.

As errors passed to `JSON.stringify` just result in an empty object being output (normally), a custom replacer function is now included to fix that

Let me know if there's anything else that needs to be done to have this included. Terminus has been fantastic in our k8s environment!