### PR TITLE
feature: added options for after shutdown signal

### DIFF
--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -128,7 +128,7 @@ function decorateWithSignalHandler (server, state, options) {
         await onSignal()
         await onShutdown()
         signals.forEach(sig => process.removeListener(sig, cleanup))
-        process.kill(process.pid, signal)
+        if (options.afterShutdownKillExecution) process.kill(process.pid, signal);
       } catch (error) {
         logger('error happened during shutdown', error)
         process.exit(1)
@@ -162,7 +162,8 @@ function terminus (server, options = {}) {
     onShutdown = noopResolves,
     beforeShutdown = noopResolves,
     logger = noop,
-    caseInsensitive = false
+    caseInsensitive = false,
+    afterShutdownKillExecution = true
   } = options
   const onSignal = options.onSignal || options.onSigterm || noopResolves
   const state = Object.assign({}, intialState)
@@ -186,7 +187,8 @@ function terminus (server, options = {}) {
     beforeShutdown,
     onShutdown,
     timeout,
-    logger
+    logger,
+    afterShutdownKillExecution
   })
 
   return server


### PR DESCRIPTION
Unconditional service is to die. if the `SIGTERM`.
When using multiple Connection formats in one service, we can limit the use of Kill signals because we need to process Graceful for all services.

```javascript
const http = require('http');
const Koa = require('koa');
const app = new Koa();

const server = http.createServer(app.callback());
const options = {
  afterShutdownKillExecution: false
};
createTerminus(server, options);
server.listen(PORT || 3000);
```

# Control Sigterm
```javascript
process.emit(`SIGTERM`);

// terminus Handlring Singal... 

// And Other Service destory
OtherService.destory().then(process.kill(pid)); 
```