### PR TITLE
Added an option for custom failure status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,17 @@ const options = {
     __unsafeExposeStackTraces: true // [optional = false] return stack traces in error response if healthchecks throw errors
   },
   caseInsensitive, // [optional] whether given health checks routes are case insensitive (defaults to false)
+  failureStatusCode, // [optional] HTTP status code for health check failure(s) (defaults to 503)
 
   // cleanup options
   timeout: 1000,                   // [optional = 1000] number of milliseconds before forceful exiting
   signal,                          // [optional = 'SIGTERM'] what signal to listen for relative to shutdown
   signals,                         // [optional = []] array of signals to listen for relative to shutdown
-  sendFailuresDuringShutdown,      // [optional = true] whether or not to send failure (503) during shutdown
+  sendFailuresDuringShutdown,      // [optional = true] whether or not to send failure status code during shutdown
   beforeShutdown,                  // [optional] called before the HTTP server starts its shutdown
   onSignal,                        // [optional] cleanup function, returning a promise (used to be onSigterm)
   onShutdown,                      // [optional] called right before exiting
-  onSendFailureDuringShutdown,     // [optional] called before sending each 503 during shutdowns
+  onSendFailureDuringShutdown,     // [optional] called before sending each failure status code during shutdowns
 
   // both
   logger                           // [optional] logger function to be called with errors. Example logger call: ('error happened during shutdown', error). See terminus.js for more details.

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -34,7 +34,7 @@ async function sendSuccess (res, { info, verbatim }) {
 }
 
 async function sendFailure (res, options) {
-  const { error, onSendFailureDuringShutdown, exposeStackTraces } = options
+  const { error, onSendFailureDuringShutdown, exposeStackTraces, failureStatusCode } = options
 
   function replaceErrors (_, value) {
     if (value instanceof Error) {
@@ -54,7 +54,7 @@ async function sendFailure (res, options) {
   if (onSendFailureDuringShutdown) {
     await onSendFailureDuringShutdown()
   }
-  res.statusCode = 503
+  res.statusCode = failureStatusCode
   res.setHeader('Content-Type', 'application/json')
   if (error) {
     return res.end(JSON.stringify({
@@ -73,7 +73,7 @@ const intialState = {
 function noop () {}
 
 function decorateWithHealthCheck (server, state, options) {
-  const { healthChecks, logger, onSendFailureDuringShutdown, sendFailuresDuringShutdown, caseInsensitive } = options
+  const { healthChecks, logger, onSendFailureDuringShutdown, sendFailuresDuringShutdown, caseInsensitive, failureStatusCode } = options
 
   let hasSetHandler = false
   const createHandler = (listener) => {
@@ -81,14 +81,14 @@ function decorateWithHealthCheck (server, state, options) {
       ? () => {}
       : async (healthCheck, res) => {
         if (state.isShuttingDown && sendFailuresDuringShutdown) {
-          return sendFailure(res, { onSendFailureDuringShutdown })
+          return sendFailure(res, { onSendFailureDuringShutdown, failureStatusCode })
         }
         let info
         try {
           info = await healthCheck({ state })
         } catch (error) {
           logger('healthcheck failed', error)
-          return sendFailure(res, { error: error.causes, exposeStackTraces: healthChecks.__unsafeExposeStackTraces })
+          return sendFailure(res, { error: error.causes, exposeStackTraces: healthChecks.__unsafeExposeStackTraces, failureStatusCode })
         }
         return sendSuccess(res, { info, verbatim: healthChecks.verbatim })
       }
@@ -162,7 +162,8 @@ function terminus (server, options = {}) {
     onShutdown = noopResolves,
     beforeShutdown = noopResolves,
     logger = noop,
-    caseInsensitive = false
+    caseInsensitive = false,
+    failureStatusCode = 503
   } = options
   const onSignal = options.onSignal || options.onSigterm || noopResolves
   const state = Object.assign({}, intialState)
@@ -173,7 +174,8 @@ function terminus (server, options = {}) {
       logger,
       sendFailuresDuringShutdown,
       onSendFailureDuringShutdown,
-      caseInsensitive
+      caseInsensitive,
+      failureStatusCode
     })
   }
 

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -216,6 +216,31 @@ describe('Terminus', () => {
       expect(loggerRan).to.eql(true)
     })
 
+    it('returns custom status code on reject', async () => {
+      let onHealthCheckRan = false
+      let loggerRan = false
+      const failureStatusCode = 501
+
+      createTerminus(server, {
+        healthChecks: {
+          '/health': () => {
+            onHealthCheckRan = true
+            return Promise.reject(new Error('failed'))
+          }
+        },
+        logger: () => {
+          loggerRan = true
+        },
+        failureStatusCode
+      })
+      server.listen(8000)
+
+      const res = await fetch('http://localhost:8000/health')
+      expect(res.status).to.eql(failureStatusCode)
+      expect(onHealthCheckRan).to.eql(true)
+      expect(loggerRan).to.eql(true)
+    })
+
     it('exposes internal state (isShuttingDown: false) to health check', async () => {
       let onHealthCheckRan = false
       let exposedState

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -15,6 +15,7 @@ declare module "@godaddy/terminus" {
   export interface TerminusOptions {
     healthChecks?: HealthCheckMap;
     caseInsensitive?: boolean;
+    failureStatusCode?: number;
     timeout?: number;
     signal?: string;
     signals?: string[];


### PR DESCRIPTION
Closes https://github.com/godaddy/terminus/issues/176.

A new optional option, called `failureStatusCode` was added to the terminus options. The option is numeric anad designates an HTTP status code terminus would use, when reporting failures. Its default value mimics the previously hard-coded value of `503`.