### PR TITLE
custom header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,40 @@ createTerminus(server, {
 });
 ```
 
+### With custom headers
+```js
+const http = require("http");
+const express = require("express");
+const { createTerminus, HealthCheckError } = require('@godaddy/terminus');
+const app = express();
+
+app.get("/", (req, res) => {
+  res.send("ok");
+});
+
+const server = http.createServer(app);
+
+function healthCheck({ state }) {
+  return Promise.resolve();
+}
+
+const options = {
+  healthChecks: {
+    "/healthcheck": healthCheck,
+    verbatim: true,
+    __unsafeExposeStackTraces: true,
+  },
+  headers: {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "OPTIONS, POST, GET",
+  },
+};
+
+terminus.createTerminus(server, options);
+
+server.listen(3000);
+```
+
 ### With express
 
 ```javascript

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -15,7 +15,7 @@ function noopResolves () {
   return Promise.resolve()
 }
 
-async function sendSuccess (res, { info, verbatim, statusOk }, headers) {
+async function sendSuccess (res, { info, verbatim, statusOk, headers }) {
   res.statusCode = statusOk
   res.setHeader('Content-Type', 'application/json')
   res.writeHead(statusOk, headers)
@@ -34,8 +34,8 @@ async function sendSuccess (res, { info, verbatim, statusOk }, headers) {
   res.end(SUCCESS_RESPONSE)
 }
 
-async function sendFailure (res, options, headers) {
-  const { error, onSendFailureDuringShutdown, exposeStackTraces, statusCode, statusError } = options
+async function sendFailure (res, options) {
+  const { error, headers, onSendFailureDuringShutdown, exposeStackTraces, statusCode, statusError } = options
 
   function replaceErrors (_, value) {
     if (value instanceof Error) {
@@ -74,8 +74,8 @@ const intialState = {
 
 function noop () {}
 
-function decorateWithHealthCheck (server, state, options, headers) {
-  const { healthChecks, logger, onSendFailureDuringShutdown, sendFailuresDuringShutdown, caseInsensitive, statusOk, statusError } = options
+function decorateWithHealthCheck (server, state, options) {
+  const { healthChecks, logger, headers, onSendFailureDuringShutdown, sendFailuresDuringShutdown, caseInsensitive, statusOk, statusError } = options
 
   let hasSetHandler = false
   const createHandler = (listener) => {
@@ -94,17 +94,16 @@ function decorateWithHealthCheck (server, state, options, headers) {
             res,
             {
               error: error.causes,
+              headers,
               exposeStackTraces: healthChecks.__unsafeExposeStackTraces,
               statusCode: error.statusCode,
               statusError
             },
-            headers
           )
         }
         return sendSuccess(
           res,
-          { info, verbatim: healthChecks.verbatim, statusOk },
-          headers
+          { info, verbatim: healthChecks.verbatim, statusOk, headers }
         )
       }
 
@@ -180,7 +179,8 @@ function terminus (server, options = {}) {
     logger = noop,
     caseInsensitive = false,
     statusOk = 200,
-    statusError = 503
+    statusError = 503,
+    headers = options.headers || {}
   } = options
   const onSignal = options.onSignal || options.onSigterm || noopResolves
   const state = Object.assign({}, intialState)
@@ -193,8 +193,9 @@ function terminus (server, options = {}) {
       onSendFailureDuringShutdown,
       caseInsensitive,
       statusOk,
-      statusError
-    }, options.headers)
+      statusError,
+      headers
+    })
   }
 
   // push the signal into the array
@@ -206,8 +207,9 @@ function terminus (server, options = {}) {
     beforeShutdown,
     onShutdown,
     timeout,
-    logger
-  }, options.headers)
+    logger,
+    headers
+  })
 
   return server
 }

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -18,7 +18,7 @@ function noopResolves () {
 async function sendSuccess (res, { info, verbatim, statusOk }, headers) {
   res.statusCode = statusOk
   res.setHeader('Content-Type', 'application/json')
-  res.writeHead(statusOk, headers);
+  res.writeHead(statusOk, headers)
   if (info) {
     return res.end(
       JSON.stringify(
@@ -57,7 +57,7 @@ async function sendFailure (res, options, headers) {
   }
   res.statusCode = statusCode || statusError
   res.setHeader('Content-Type', 'application/json')
-  res.writeHead(statusCode || statusError, headers);
+  res.writeHead(statusCode || statusError, headers)
   if (error) {
     return res.end(JSON.stringify({
       status: 'error',
@@ -96,16 +96,16 @@ function decorateWithHealthCheck (server, state, options, headers) {
               error: error.causes,
               exposeStackTraces: healthChecks.__unsafeExposeStackTraces,
               statusCode: error.statusCode,
-              statusError,
+              statusError
             },
             headers
-          );
+          )
         }
         return sendSuccess(
           res,
           { info, verbatim: healthChecks.verbatim, statusOk },
           headers
-        );
+        )
       }
 
     hasSetHandler = true
@@ -193,7 +193,7 @@ function terminus (server, options = {}) {
       onSendFailureDuringShutdown,
       caseInsensitive,
       statusOk,
-      statusError,
+      statusError
     }, options.headers)
   }
 

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -16,7 +16,6 @@ function noopResolves () {
 }
 
 async function sendSuccess (res, { info, verbatim, statusOk, headers }) {
-  res.statusCode = statusOk
   res.setHeader('Content-Type', 'application/json')
   res.writeHead(statusOk, headers)
   if (info) {
@@ -55,7 +54,6 @@ async function sendFailure (res, options) {
   if (onSendFailureDuringShutdown) {
     await onSendFailureDuringShutdown()
   }
-  res.statusCode = statusCode || statusError
   res.setHeader('Content-Type', 'application/json')
   res.writeHead(statusCode || statusError, headers)
   if (error) {
@@ -98,7 +96,7 @@ function decorateWithHealthCheck (server, state, options) {
               exposeStackTraces: healthChecks.__unsafeExposeStackTraces,
               statusCode: error.statusCode,
               statusError
-            },
+            }
           )
         }
         return sendSuccess(

--- a/lib/terminus.js
+++ b/lib/terminus.js
@@ -15,9 +15,10 @@ function noopResolves () {
   return Promise.resolve()
 }
 
-async function sendSuccess (res, { info, verbatim, statusOk }) {
+async function sendSuccess (res, { info, verbatim, statusOk }, headers) {
   res.statusCode = statusOk
   res.setHeader('Content-Type', 'application/json')
+  res.writeHead(statusOk, headers);
   if (info) {
     return res.end(
       JSON.stringify(
@@ -33,7 +34,7 @@ async function sendSuccess (res, { info, verbatim, statusOk }) {
   res.end(SUCCESS_RESPONSE)
 }
 
-async function sendFailure (res, options) {
+async function sendFailure (res, options, headers) {
   const { error, onSendFailureDuringShutdown, exposeStackTraces, statusCode, statusError } = options
 
   function replaceErrors (_, value) {
@@ -56,6 +57,7 @@ async function sendFailure (res, options) {
   }
   res.statusCode = statusCode || statusError
   res.setHeader('Content-Type', 'application/json')
+  res.writeHead(statusCode || statusError, headers);
   if (error) {
     return res.end(JSON.stringify({
       status: 'error',
@@ -72,7 +74,7 @@ const intialState = {
 
 function noop () {}
 
-function decorateWithHealthCheck (server, state, options) {
+function decorateWithHealthCheck (server, state, options, headers) {
   const { healthChecks, logger, onSendFailureDuringShutdown, sendFailuresDuringShutdown, caseInsensitive, statusOk, statusError } = options
 
   let hasSetHandler = false
@@ -88,9 +90,22 @@ function decorateWithHealthCheck (server, state, options) {
           info = await healthCheck({ state })
         } catch (error) {
           logger('healthcheck failed', error)
-          return sendFailure(res, { error: error.causes, exposeStackTraces: healthChecks.__unsafeExposeStackTraces, statusCode: error.statusCode, statusError })
+          return sendFailure(
+            res,
+            {
+              error: error.causes,
+              exposeStackTraces: healthChecks.__unsafeExposeStackTraces,
+              statusCode: error.statusCode,
+              statusError,
+            },
+            headers
+          );
         }
-        return sendSuccess(res, { info, verbatim: healthChecks.verbatim, statusOk })
+        return sendSuccess(
+          res,
+          { info, verbatim: healthChecks.verbatim, statusOk },
+          headers
+        );
       }
 
     hasSetHandler = true
@@ -98,6 +113,7 @@ function decorateWithHealthCheck (server, state, options) {
     return async (req, res) => {
       const url = caseInsensitive ? req.url.toLowerCase() : req.url
       const healthCheck = healthChecks[url]
+
       if (healthCheck) {
         return check(healthCheck, res)
       } else {
@@ -177,8 +193,8 @@ function terminus (server, options = {}) {
       onSendFailureDuringShutdown,
       caseInsensitive,
       statusOk,
-      statusError
-    })
+      statusError,
+    }, options.headers)
   }
 
   // push the signal into the array
@@ -191,7 +207,7 @@ function terminus (server, options = {}) {
     onShutdown,
     timeout,
     logger
-  })
+  }, options.headers)
 
   return server
 }

--- a/lib/terminus.spec.js
+++ b/lib/terminus.spec.js
@@ -656,4 +656,27 @@ describe('Terminus', () => {
       'server3:onSignal'
     ].join('\n'))
   })
+
+  it('accepts custom headers', async () => {
+  
+  createTerminus(server, {
+    healthChecks: {
+      '/health': () => {
+        return Promise.resolve()
+      }
+    },
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "OPTIONS, POST, GET",
+    },
+  })
+  server.listen(8000)
+
+  const res = await fetch('http://localhost:8000/health')
+  expect(res.status).to.eql(200)
+  expect(res.headers.has('Access-Control-Allow-Methods')).to.eql(true)
+  expect(res.headers.get('Access-Control-Allow-Methods')).to.eql('OPTIONS, POST, GET')
+  expect(res.headers.has('Access-Control-Allow-Origin')).to.eql(true)
+  expect(res.headers.get('Access-Control-Allow-Origin')).to.eql('*')
+  })
 })


### PR DESCRIPTION
fixes #195 

- Added changes to allow for headers to be written
- I also updated the documents to show how to include headers to be written. 

An example on how to write headers would be: 
```js
const http = require("http");
const express = require("express");
const terminus = require("../terminus/index.js");
const app = express();

app.get("/", (req, res) => {
  res.send("ok");
});

const server = http.createServer(app);

function healthCheck({ state }) {
  // `state.isShuttingDown` (boolean) shows whether the server is shutting down or not
  return Promise
    .resolve
    // optionally include a resolve value to be included as
    // info in the health check response
    ();
}

const options = {
  healthChecks: {
    "/healthcheck": healthCheck,
    verbatim: true,
    __unsafeExposeStackTraces: true,
  },
  headers: {
    "Access-Control-Allow-Origin": "*",
    "Access-Control-Allow-Methods": "OPTIONS, POST, GET",
  },
};

terminus.createTerminus(server, options);

server.listen(3000);
```

I tested it to enable CORS headers and everything seems to be working!