### PR TITLE
fix(useExit0): add ts definition

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -25,6 +25,7 @@ declare module "@godaddy/terminus" {
     sendFailuresDuringShutdown?: boolean;
     statusOk?: number,
     statusError?: number,
+    useExit0?: boolean,
     onSignal?: () => Promise<any>;
     onSendFailureDuringShutdown?: () => Promise<any>;
     onShutdown?: () => Promise<any>;


### PR DESCRIPTION
It seems like the typings for the new parameter was missed. This adds it in.