### PR TITLE
Support non-promise function options in TypeScript

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,7 +3,7 @@ declare module "@godaddy/terminus" {
     isShuttingDown: boolean;
   }
 
-  export type HealthCheck = ({ state }: { state: TerminusState }) => Promise<any>;
+  export type HealthCheck = ({ state }: { state: TerminusState }) => Promise<any> | any;
 
   export class HealthCheckError extends Error {
     constructor(message: string, causes: any);
@@ -28,10 +28,10 @@ declare module "@godaddy/terminus" {
     statusError?: number,
     statusErrorResponse?: Record<string, unknown>,
     useExit0?: boolean,
-    onSignal?: () => Promise<any>;
-    onSendFailureDuringShutdown?: () => Promise<any>;
-    onShutdown?: () => Promise<any>;
-    beforeShutdown?: () => Promise<any>;
+    onSignal?: () => Promise<any> | void;
+    onSendFailureDuringShutdown?: () => Promise<any> | void;
+    onShutdown?: () => Promise<any> | void;
+    beforeShutdown?: () => Promise<any> | void;
     logger?: (msg: string, err: Error) => void;
     headers?:{ [key: string]: string };
 

--- a/typings/index.test.ts
+++ b/typings/index.test.ts
@@ -8,9 +8,13 @@ async function onSignal() {
   ]);
 }
 
-async function onShutdown() {
+async function onShutdownAsync() {
   console.log('cleanup finished, server is shutting down');
-  return Promise.resolve();
+  return true;
+}
+
+const onShutdown: TerminusOptions["onShutdown"] = () => {
+  console.log('cleanup finished, server is shutting down');
 }
 
 const server = http.createServer((request, response) => {
@@ -23,14 +27,25 @@ const healthcheck: HealthCheck = () => {
   throw error;
 }
 
+const healthcheckAsync: HealthCheck = async () => {
+  const result = await Promise.resolve([{ status: 'up' }]);
+  return result;
+}
+
+const healthcheckSync: HealthCheck = () => {
+  return [{ status: 'up' }];
+}
+
 const options: TerminusOptions = {
   healthChecks: {
     "/healthcheck": healthcheck,
+    "/healthcheck-sync": healthcheckSync,
+    "/healthcheck-async": healthcheckAsync,
     verbatim: true
   },
   timeout: 1000,
   onSignal,
-  onShutdown,
+  onShutdown: onShutdownAsync,
   logger: console.log
 };
 


### PR DESCRIPTION
## Summary

Hey folks, thanks for the library! This is a small change to the types, with no functional changes, which should hopefully make things a tiny bit cleaner for users.

---

These functions don't really _need_ to be async but currently the types require that they are. For example, currently this is an invalid option:

```typescript
onSignal: () => logger.info("signal received")
```

and instead you'd have to write:

```typescript
onSignal: async () => logger.info("signal received")
```

which might trigger a linter error such as typescript-eslint's `Async method 'onSignal' has no 'await' expression.`

or

```typescript
onSignal: () => {
  logger.info("signal received")
  return Promise.resolve()
}
```

which creates a promise for no reason other than to satisfy the types!

With this PR the types make it clear that you can actually just return nothing or, in the case of the health checks, return a value without using async/await or creating a promise.


## Changelog

Update types to support non-promise function options
